### PR TITLE
More specific grep to verify mountpoint

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -195,7 +195,7 @@ function log.error() {
 mount -t btrfs | cut -d " " -f 3 | grep "^${mp}$" > /dev/null
 if [ $? -ne 0 ] ; then
     # or a valid snapshot matching mp
-    btrfs subvolume show $mp | grep $(basename $mp) > /dev/null
+    btrfs subvolume show $mp | grep "$(basename $mp)$" > /dev/null
     if [ $? -ne 0 ] ; then
         log.error "${mp} is not a btrfs mountpoint (or old version of btrfs-tools, try > 0.19)"
         exit 1;


### PR DESCRIPTION
Just `$(basename $mp)` is too unspecific, because if you pass following parameter:
`/btrfs/system/volume-1`
you will also match
`/btrfs/system/volume-11`
`/btrfs/system/volume-111`
and so on.